### PR TITLE
docs(): change repository.url to "nestjs/schedule"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nestjs/config"
+    "url": "https://github.com/nestjs/schedule"
   }
 }


### PR DESCRIPTION
The reference of repository in npm page is wrong. Change the package.json to fix.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Other... Please describe: Fix docs related to npm
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The reference of repository in npm is "github.com/nestjs/config" which is wrong.

Issue Number: N/A


## What is the new behavior?
The reference may be fixed. I am not sure because I never publish any package to npm.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information