### PR TITLE
bugfix(schedule): Handle null prototype providers

### DIFF
--- a/lib/schedule.explorer.ts
+++ b/lib/schedule.explorer.ts
@@ -23,7 +23,7 @@ export class ScheduleExplorer implements OnModuleInit {
     const providers: InstanceWrapper[] = this.discoveryService.getProviders();
     providers.forEach((wrapper: InstanceWrapper) => {
       const { instance } = wrapper;
-      if (!instance) {
+      if (!instance || !Object.getPrototypeOf(instance)) {
         return;
       }
       this.metadataScanner.scanFromPrototype(

--- a/tests/e2e/cron-jobs.spec.ts
+++ b/tests/e2e/cron-jobs.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { CronService } from '../src/cron.service';
+import { nullPrototypeObjectProvider } from '../src/null-prototype-object.provider';
 import sinon from 'sinon';
 
 const deleteAllRegisteredJobsExceptOne = (
@@ -10,8 +11,8 @@ const deleteAllRegisteredJobsExceptOne = (
   name: string,
 ) => {
   Array.from(registry.getCronJobs().keys())
-    .filter(key => key !== name)
-    .forEach(item => registry.deleteCronJob(item));
+    .filter((key) => key !== name)
+    .forEach((item) => registry.deleteCronJob(item));
 };
 
 describe('Cron', () => {
@@ -145,6 +146,17 @@ describe('Cron', () => {
         'No Cron Job was found with the given name (dynamic). Check that you created one with a decorator or with the create API.',
       );
     }
+  });
+
+  it(`should initialize when the consuming module contains a provider with a null prototype`, async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.registerCron()],
+      providers: [nullPrototypeObjectProvider],
+    }).compile();
+    app = module.createNestApplication();
+
+    const instance = await app.init();
+    expect(instance).toBeDefined();
   });
 
   afterEach(async () => {

--- a/tests/e2e/interval.spec.ts
+++ b/tests/e2e/interval.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { IntervalService } from '../src/interval.service';
+import { nullPrototypeObjectProvider } from '../src/null-prototype-object.provider';
 
 describe('Interval', () => {
   let app: INestApplication;
@@ -71,6 +72,17 @@ describe('Interval', () => {
         'No Interval was found with the given name (dynamic). Check that you created one with a decorator or with the create API.',
       );
     }
+  });
+
+  it(`should initialize when the consuming module contains a provider with a null prototype`, async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.registerInterval()],
+      providers: [nullPrototypeObjectProvider],
+    }).compile();
+    app = module.createNestApplication();
+
+    const instance = await app.init();
+    expect(instance).toBeDefined();
   });
 
   afterEach(async () => {

--- a/tests/e2e/timeout.spec.ts
+++ b/tests/e2e/timeout.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { TimeoutService } from '../src/timeout.service';
+import { nullPrototypeObjectProvider } from '../src/null-prototype-object.provider';
 
 describe('Timeout', () => {
   let app: INestApplication;
@@ -72,6 +73,17 @@ describe('Timeout', () => {
         'No Timeout was found with the given name (dynamic). Check that you created one with a decorator or with the create API.',
       );
     }
+  });
+
+  it(`should initialize when the consuming module contains a provider with a null prototype`, async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.registerTimeout()],
+      providers: [nullPrototypeObjectProvider],
+    }).compile();
+    app = module.createNestApplication();
+
+    const instance = await app.init();
+    expect(instance).toBeDefined();
   });
 
   afterEach(async () => {

--- a/tests/src/null-prototype-object.provider.ts
+++ b/tests/src/null-prototype-object.provider.ts
@@ -1,0 +1,6 @@
+import { Provider } from '@nestjs/common';
+
+export const nullPrototypeObjectProvider: Provider = {
+  provide: 'NULL_PROTOTYPE_OBJECT',
+  useValue: Object.create(null),
+};


### PR DESCRIPTION
Correctly handle providers that have a null prototype in the `ScheduleExplorer`.

This bug fix resolves issue #142.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #142


## What is the new behavior?
Providers that consist of an object with a null prototype are not processed by the `MetadataScanner`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information