### PR TITLE
bugfix(scheduler): cleanup jobs on application shutdown

### DIFF
--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -43,7 +43,7 @@ export class SchedulerOrchestrator
 
   mountIntervals() {
     const intervalKeys = Object.keys(this.intervals);
-    intervalKeys.forEach(key => {
+    intervalKeys.forEach((key) => {
       const options = this.intervals[key];
       const intervalRef = setInterval(options.target, options.timeout);
 
@@ -54,7 +54,7 @@ export class SchedulerOrchestrator
 
   mountTimeouts() {
     const timeoutKeys = Object.keys(this.timeouts);
-    timeoutKeys.forEach(key => {
+    timeoutKeys.forEach((key) => {
       const options = this.timeouts[key];
       const timeoutRef = setTimeout(options.target, options.timeout);
 
@@ -65,7 +65,7 @@ export class SchedulerOrchestrator
 
   mountCron() {
     const cronKeys = Object.keys(this.cronJobs);
-    cronKeys.forEach(key => {
+    cronKeys.forEach((key) => {
       const { options, target } = this.cronJobs[key];
       const cronJob = new CronJob(
         options.cronTime,
@@ -86,18 +86,21 @@ export class SchedulerOrchestrator
   }
 
   clearTimeouts() {
-    const keys = Object.keys(this.timeouts);
-    keys.forEach(key => clearTimeout(this.timeouts[key].ref));
+    Array.from(this.schedulerRegistry.getTimeouts()).forEach((key) =>
+      this.schedulerRegistry.deleteTimeout(key),
+    );
   }
 
   clearIntervals() {
-    const keys = Object.keys(this.intervals);
-    keys.forEach(key => clearInterval(this.intervals[key].ref));
+    Array.from(this.schedulerRegistry.getIntervals()).forEach((key) =>
+      this.schedulerRegistry.deleteInterval(key),
+    );
   }
 
   closeCronJobs() {
-    const keys = Object.keys(this.cronJobs);
-    keys.forEach(key => this.cronJobs[key].ref!.stop());
+    Array.from(this.schedulerRegistry.getCronJobs().keys()).forEach((key) =>
+      this.schedulerRegistry.deleteCronJob(key),
+    );
   }
 
   addTimeout(methodRef: Function, timeout: number, name: string = v4()) {

--- a/tests/e2e/cron-jobs.spec.ts
+++ b/tests/e2e/cron-jobs.spec.ts
@@ -159,6 +159,19 @@ describe('Cron', () => {
     expect(instance).toBeDefined();
   });
 
+  it('should clean up dynamic cron jobs on application shutdown', async () => {
+    const service = app.get(CronService);
+    await app.init();
+    service.addCronJob();
+
+    const registry = app.get(SchedulerRegistry);
+
+    await app.close();
+
+    expect(registry.getCronJobs().size).toBe(0);
+    expect(clock.countTimers()).toBe(0);
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/tests/e2e/interval.spec.ts
+++ b/tests/e2e/interval.spec.ts
@@ -85,6 +85,19 @@ describe('Interval', () => {
     expect(instance).toBeDefined();
   });
 
+  it('should clean up dynamic intervals on application shutdown', async () => {
+    const service = app.get(IntervalService);
+    await app.init();
+    service.addInterval();
+
+    const registry = app.get(SchedulerRegistry);
+
+    await app.close();
+
+    expect(registry.getIntervals().length).toBe(0);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/tests/e2e/timeout.spec.ts
+++ b/tests/e2e/timeout.spec.ts
@@ -86,6 +86,19 @@ describe('Timeout', () => {
     expect(instance).toBeDefined();
   });
 
+  it('should clean up dynamic timeouts on application shutdown', async () => {
+    const service = app.get(TimeoutService);
+    await app.init();
+    service.addTimeout();
+
+    const registry = app.get(SchedulerRegistry);
+
+    await app.close();
+
+    expect(registry.getTimeouts().length).toBe(0);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
   afterEach(async () => {
     await app.close();
   });


### PR DESCRIPTION
Stop and delete all jobs, including dynamic ones. Perform the cleanup in
SchedulerRegistry, since it holds the up-to-date records of running
jobs.

Fixes #326

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Only the jobs planned at application start are cleaned up when the application shuts down.

Issue Number: #326 


## What is the new behavior?
All the jobs currently registered are stopped on application shutdown.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information