### PR TITLE
refactor: drop useless array creation from `SchedulerOrchestrator`

### DIFF
--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -86,13 +86,13 @@ export class SchedulerOrchestrator
   }
 
   clearTimeouts() {
-    Array.from(this.schedulerRegistry.getTimeouts()).forEach((key) =>
+    this.schedulerRegistry.getTimeouts().forEach((key) =>
       this.schedulerRegistry.deleteTimeout(key),
     );
   }
 
   clearIntervals() {
-    Array.from(this.schedulerRegistry.getIntervals()).forEach((key) =>
+    this.schedulerRegistry.getIntervals().forEach((key) =>
       this.schedulerRegistry.deleteInterval(key),
     );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We are basically doing the following:

```js
const keys = ['a', 'b'];
Array.from(keys).forEach(key => {});
// two we have 2 arrays in memory
```

and I don't see any reason to do that.

## What is the new behavior?

Don't call `Array.from` anymore as it isn't needed

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

To be honest, I believe the following two methods from `SchedulerRegistry`

https://github.com/nestjs/schedule/blob/000c8f480a8af7e0286b4d0cd4086cc790e39598/lib/scheduler.registry.ts#L87-L89

https://github.com/nestjs/schedule/blob/000c8f480a8af7e0286b4d0cd4086cc790e39598/lib/scheduler.registry.ts#L97-L99

should have the same interface as the `getCronJobs` one. But I guess change that would introduce breaking changes since those methods on `SchedulerRegistry` are public :thinking: 

https://github.com/nestjs/schedule/blob/000c8f480a8af7e0286b4d0cd4086cc790e39598/lib/scheduler.registry.ts#L77-L79