### PR TITLE
refactor: log class name as context on exception

### DIFF
--- a/lib/schedule.explorer.ts
+++ b/lib/schedule.explorer.ts
@@ -122,7 +122,7 @@ export class ScheduleExplorer implements OnModuleInit {
       try {
         await methodRef.call(instance, ...args);
       } catch (error) {
-        this.logger.error(error);
+        Logger.error(error, instance.constructor.name);
       }
     };
   }

--- a/tests/src/cron.service.ts
+++ b/tests/src/cron.service.ts
@@ -46,6 +46,13 @@ export class CronService {
     }
   }
 
+  @Cron(CronExpression.EVERY_MINUTE, {
+    name: 'THROW_EXCEPTION_EVERY_MINUTE',
+  })
+  handleCronThrowException() {
+    throw new Error('Cron Exception')
+  }
+
   @Cron(CronExpression.EVERY_HOUR, {
     name: 'EXECUTES_EVERY_HOUR',
   })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #956 


## What is the new behavior?

Before this change:

<img width="576" alt="image" src="https://user-images.githubusercontent.com/10992150/175033840-dc30d715-4a3e-4211-8ea0-724fbf9634c9.png">


After this change:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/10992150/175033728-0d3c3d3d-4df8-4459-8c10-c665eeab9b5c.png">

Notice that the context is the called class (`[CronService]`) and not explorer class (`[Scheduler]`)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No