### PR TITLE
ci: fix to always use npm v8 instead of latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update NPM version
-          command: npm install -g npm@latest
+          name: Use NPM v8
+          command: npm install -g npm@^8
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:


### PR DESCRIPTION
this will fix the following build error:

![image](https://user-images.githubusercontent.com/13461315/208252690-4040e95f-1b2f-4881-99d8-bea8e8c90b98.png)
