### PR TITLE
feat: remove deprecated `SchedulerRegistry#doesExists` method

### DIFF
--- a/lib/scheduler.registry.ts
+++ b/lib/scheduler.registry.ts
@@ -10,11 +10,6 @@ export class SchedulerRegistry {
   private readonly timeouts = new Map<string, any>();
   private readonly intervals = new Map<string, any>();
 
-  /**
-   * @deprecated Use the `doesExist` method instead.
-   */
-  // TODO(v2): drop this.
-  doesExists = this.doesExist;
   doesExist(type: 'cron' | 'timeout' | 'interval', name: string) {
     switch (type) {
       case 'cron':


### PR DESCRIPTION
that method was deprecated in v1 and was supposed to be removed in v2

not sure if we can remove that now as we released v3.0.0 already :thinking: 