### PR TITLE
chore(deps): remove dev dependency @types/cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Schedule module for [Nest](https://github.com/nestjs/nest) based on the [cron](h
 
 ```bash
 $ npm install --save @nestjs/schedule
-$ npm install --save-dev @types/cron
 ```
 
 ## Quick Start

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@nestjs/core": "10.2.0",
         "@nestjs/platform-express": "10.2.0",
         "@nestjs/testing": "10.2.0",
-        "@types/cron": "2.0.1",
         "@types/jest": "29.5.3",
         "@types/node": "18.17.6",
         "@types/sinon": "10.0.16",
@@ -3004,16 +3003,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/cron": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.0.1.tgz",
-      "integrity": "sha512-WHa/1rtNtD2Q/H0+YTTZoty+/5rcE66iAFX2IY+JuUoOACsevYyFkSYu/2vdw+G5LrmO7Lxowrqm0av4k3qWNQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/luxon": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -3073,12 +3062,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/luxon": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-      "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
       "dev": true
     },
     "node_modules/@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@nestjs/core": "10.2.0",
     "@nestjs/platform-express": "10.2.0",
     "@nestjs/testing": "10.2.0",
-    "@types/cron": "2.0.1",
     "@types/jest": "29.5.3",
     "@types/node": "18.17.6",
     "@types/sinon": "10.0.16",


### PR DESCRIPTION
Since @renovate-bot force-pushed `renovate/cron-2.x` (https://github.com/nestjs/schedule/pull/1355) after https://github.com/nestjs/schedule/pull/1356 had been merged into it, the changes were lost and did not reach the `master` branch. This PR reintroduces these changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: `Development dependencies & documentation update`


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information

Reproduces PR: https://github.com/nestjs/schedule/pull/1356

Commands ran (successfully) to test the changes:
```bash
$ npm run build
$ npm run test:integration
```