### PR TITLE
refactor: ignore non-objects in metadata accessor

### DIFF
--- a/lib/schedule-metadata.accessor.ts
+++ b/lib/schedule-metadata.accessor.ts
@@ -17,24 +17,33 @@ export class SchedulerMetadataAccessor {
   constructor(private readonly reflector: Reflector) {}
 
   getSchedulerType(target: Function): SchedulerType | undefined {
-    return this.reflector.get(SCHEDULER_TYPE, target);
+    return this.getMetadata(SCHEDULER_TYPE, target);
   }
 
   getSchedulerName(target: Function): string | undefined {
-    return this.reflector.get(SCHEDULER_NAME, target);
+    return this.getMetadata(SCHEDULER_NAME, target);
   }
 
   getTimeoutMetadata(target: Function): TimeoutMetadata | undefined {
-    return this.reflector.get(SCHEDULE_TIMEOUT_OPTIONS, target);
+    return this.getMetadata(SCHEDULE_TIMEOUT_OPTIONS, target);
   }
 
   getIntervalMetadata(target: Function): IntervalMetadata | undefined {
-    return this.reflector.get(SCHEDULE_INTERVAL_OPTIONS, target);
+    return this.getMetadata(SCHEDULE_INTERVAL_OPTIONS, target);
   }
 
   getCronMetadata(
     target: Function,
   ): (CronOptions & Record<'cronTime', string | Date | any>) | undefined {
-    return this.reflector.get(SCHEDULE_CRON_OPTIONS, target);
+    return this.getMetadata(SCHEDULE_CRON_OPTIONS, target);
+  }
+
+  private getMetadata<T>(key: string, target: Function): T | undefined {
+    const isObject =
+      typeof target === 'object'
+        ? target !== null
+        : typeof target === 'function';
+
+    return isObject ? this.reflector.get(key, target) : undefined;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, the `onModuleInit` hook of the schedule module will traverse every controller and provider to determine the schedulers that are set up in them or anywhere in their dependency tree. If the prototype of any of these classes contains a method that no longer exists later on, the explorer will try to process that method too, eventually resulting in the following error which prevents the Nest application from starting:

```
/home/joe/..../node_modules/reflect-metadata/Reflect.js:354
                throw new TypeError();
                      ^
TypeError:
    at Reflect.getMetadata (/home/joe/..../node_modules/reflect-metadata/Reflect.js:354:23)
    at Reflector.get (/home/joe/..../node_modules/@nestjs/core/services/reflector.service.js:24:24)
    at SchedulerMetadataAccessor.getSchedulerType (/home/joe/..../node_modules/@nestjs/schedule/dist/schedule-metadata.accessor.js:21:31)
    at ScheduleExplorer.lookupSchedulers (/home/joe/..../node_modules/@nestjs/schedule/dist/schedule.explorer.js:46:48)
    at /home/joe/..../node_modules/@nestjs/schedule/dist/schedule.explorer.js:40:24
    at MetadataScanner.scanFromPrototype (/home/joe/..../node_modules/@nestjs/core/metadata-scanner.js:34:31)
    at /home/joe/..../node_modules/@nestjs/schedule/dist/schedule.explorer.js:39:34
    at Array.forEach (<anonymous>)
    at ScheduleExplorer.explore (/home/joe/..../node_modules/@nestjs/schedule/dist/schedule.explorer.js:34:26)
    at ScheduleExplorer.onModuleInit (/home/joe/..../node_modules/@nestjs/schedule/dist/schedule.explorer.js:27:14)
```

Now, this will likely not be an issue for the majority of Nest apps, however, in our particular case, we have a PrismaService which extends from the PrismaClient and we had to do some dependency injection magic that sets up some logging mechanisms and then registers a few extensions. According to [the Prisma docs](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions#usage-of-on-and-use-with-extended-clients), extending a PrismaClient will get rid of some of the methods (which, by extension, were also methods in our PrismaService), so the reflector will fail when it reaches them, throwing the abovementioned exception.

The relevant line in `reflect-metadata`: https://github.com/rbuckton/reflect-metadata/blob/3aeb98af4030be664a66f49bfd164936e0ba1825/Reflect.ts#L994

## What is the new behavior?

The behavior hasn't changed much, as the methods from the metadata accessor class can already return `undefined` if they wanted to. What I did was making sure that the instance we pass to these methods is an object before attempting to do reflection on them (using the same logic that's found inside the `reflect-metadata` package), so that they won't trigger the exception.

For now, we're using `patch-package` in our codebase and it does work as intended. Tests also pass.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Perhaps a similar fix should be implemented for all official Nest modules that use this method. Currently the only module we use that had this problem was the scheduler module.