### PR TITLE
refactor: use setAllMethodNames method

### DIFF
--- a/lib/schedule.explorer.ts
+++ b/lib/schedule.explorer.ts
@@ -27,16 +27,17 @@ export class ScheduleExplorer implements OnModuleInit {
     ];
     instanceWrappers.forEach((wrapper: InstanceWrapper) => {
       const { instance } = wrapper;
+            
       if (!instance || !Object.getPrototypeOf(instance)) {
         return;
       }
-      this.metadataScanner.scanFromPrototype(
-        instance,
-        Object.getPrototypeOf(instance),
-        (key: string) =>
-          wrapper.isDependencyTreeStatic()
-            ? this.lookupSchedulers(instance, key)
-            : this.warnForNonStaticProviders(wrapper, instance, key),
+
+      this.metadataScanner.getAllMethodNames(
+        Object.getPrototypeOf(instance)
+      ).forEach(
+        (key: string) => wrapper.isDependencyTreeStatic()
+          ? this.lookupSchedulers(instance, key)
+          : this.warnForNonStaticProviders(wrapper, instance, key),
       );
     });
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ScheduleExplorer is using  scanFromPrototype of the MetadataScanner, this method is deprecated.

Issue Number: N/A


## What is the new behavior?

I used the method getAllMethodNames for doing the same thing of the scanFromPrototype method

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
