### PR TITLE
Fix deprecated warning for interval.decorator.ts

### DIFF
--- a/lib/decorators/interval.decorator.ts
+++ b/lib/decorators/interval.decorator.ts
@@ -1,5 +1,4 @@
 import { applyDecorators, SetMetadata } from '@nestjs/common';
-import { isString } from 'util';
 import { SchedulerType } from '../enums/scheduler-type.enum';
 import {
   SCHEDULER_NAME,
@@ -22,7 +21,7 @@ export function Interval(
   nameOrTimeout: string | number,
   timeout?: number,
 ): MethodDecorator {
-  const [name, intervalTimeout] = isString(nameOrTimeout)
+  const [name, intervalTimeout] = (typeof nameOrTimeout === "string")
     ? [nameOrTimeout, timeout]
     : [undefined, nameOrTimeout];
 


### PR DESCRIPTION
[DEP0056] DeprecationWarning: The `util.isString` API is deprecated.  Please use `typeof arg === "string"` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
[DEP0056] DeprecationWarning: The `util.isString` API is deprecated.  Please use `typeof arg === "string"` instead.

Issue Number: #1757 

## What is the new behavior?
Fixed DeprecationWarning 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
