### PR TITLE
fix(scheduler): import Node.js crypto module for randomUUID usage in SchedulerOrchestrator

### DIFF
--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -4,6 +4,7 @@ import {
   OnApplicationShutdown,
 } from '@nestjs/common';
 import { CronCallback, CronJob, CronJobParams } from 'cron';
+import { randomUUID } from 'node:crypto';
 import { CronOptions } from './decorators/cron.decorator';
 import { SchedulerRegistry } from './scheduler.registry';
 
@@ -96,14 +97,22 @@ export class SchedulerOrchestrator
     );
   }
 
-  addTimeout(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+  addTimeout(
+    methodRef: Function,
+    timeout: number,
+    name: string = randomUUID(),
+  ) {
     this.timeouts[name] = {
       target: methodRef,
       timeout,
     };
   }
 
-  addInterval(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+  addInterval(
+    methodRef: Function,
+    timeout: number,
+    name: string = randomUUID(),
+  ) {
     this.intervals[name] = {
       target: methodRef,
       timeout,
@@ -114,7 +123,7 @@ export class SchedulerOrchestrator
     methodRef: Function,
     options: CronOptions & Record<'cronTime', CronJobParams['cronTime']>,
   ) {
-    const name = options.name || crypto.randomUUID();
+    const name = options.name || randomUUID();
     this.cronJobs[name] = {
       target: methodRef,
       options,


### PR DESCRIPTION
Import Node.js crypto module in SchedulerOrchestrator to prevent ReferenceError

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md  
- [ ] Tests for the changes have been added (for bug fixes / features)  
- [ ] Docs have been added / updated (for bug fixes / features)  

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix  
- [ ] Feature  
- [ ] Code style update (formatting, local variables)  
- [ ] Refactoring (no functional changes, no api changes)  
- [ ] Build related changes  
- [ ] CI related changes  
- [ ] Other... Please describe:  

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the `SchedulerOrchestrator` calls `crypto.randomUUID()` without first importing the `crypto` module, Node throws:

```
ReferenceError: crypto is not defined
at SchedulerOrchestrator.addCron (…scheduler.orchestrator.js:90:38)
```

Issue Number: N/A

## What is the new behavior?
The Node.js `crypto` module is now imported at the top of `dist/scheduler.orchestrator.js` (and the corresponding TS source). As a result, `crypto.randomUUID()` can be called without error.

## Does this PR introduce a breaking change?
- [ ] Yes  
- [x] No  

## Other information
- This relies on Node.js ≥ 14.17.0 (where `crypto.randomUUID()` was introduced).  

