### PR TITLE
test: add UTC offset to test cron jobs to prevent timezone-dependent

### DIFF
--- a/tests/src/cron.service.ts
+++ b/tests/src/cron.service.ts
@@ -14,6 +14,7 @@ export class CronService {
 
   @Cron(CronExpression.EVERY_SECOND, {
     name: 'EXECUTES_EVERY_SECOND',
+    utcOffset: 0,
   })
   handleCron() {
     ++this.callsCount;
@@ -25,6 +26,7 @@ export class CronService {
 
   @Cron(CronExpression.EVERY_30_SECONDS, {
     name: 'EXECUTES_EVERY_30_SECONDS',
+    utcOffset: 0,
   })
   handleCronEvery30Seconds() {
     ++this.callsCount;
@@ -38,6 +40,7 @@ export class CronService {
 
   @Cron(CronExpression.EVERY_MINUTE, {
     name: 'EXECUTES_EVERY_MINUTE',
+    utcOffset: 0,
   })
   handleCronEveryMinute() {
     ++this.callsCount;
@@ -49,6 +52,7 @@ export class CronService {
 
   @Cron(CronExpression.EVERY_HOUR, {
     name: 'EXECUTES_EVERY_HOUR',
+    utcOffset: 0,
   })
   handleCronEveryHour() {
     ++this.callsCount;
@@ -61,6 +65,7 @@ export class CronService {
   @Cron(CronExpression.EVERY_30_SECONDS, {
     name: 'DISABLED',
     disabled: true,
+    utcOffset: 0,
   })
   handleDisabledCron() {}
 
@@ -79,6 +84,7 @@ export class CronService {
   @Cron(CronExpression.EVERY_MINUTE, {
     name: 'WAIT_FOR_COMPLETION',
     waitForCompletion: true,
+    utcOffset: 0,
   })
   async handleLongRunningCron() {
     ++this.callsCount;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Tests were failing on systems with non-UTC timezones because cron jobs were executing based on the system timezone instead of UTC. For example, on a system with Iran Standard Time (GMT+03:30), cron jobs scheduled for "every hour" were executing at :30 minutes (00:30, 01:30, 02:30) instead of :00 minutes (01:00, 02:00, 03:00).

Issue Number: N/A


## What is the new behavior?
Added `utcOffset: 0` to all `@Cron` decorators in the test service to ensure consistent behavior across different timezone environments.
- All 42 tests now pass
- Verified on system with Iran Standard Time (GMT+03:30)
- Tests now execute at expected UTC times regardless of system timezone

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No