### PR TITLE
feat(cron): add initialDelay option to defer first job execution

### DIFF
--- a/lib/decorators/cron.decorator.ts
+++ b/lib/decorators/cron.decorator.ts
@@ -51,6 +51,14 @@ export type CronOptions = {
    *  Default is 250
    */
   threshold?: number;
+
+  /**
+   * Delay in milliseconds before the first cron execution after application bootstrap.
+   * Subsequent runs follow the normal cron schedule.
+   * Useful when the job depends on resources that are not yet ready at application startup
+   * (e.g. database connections, cache warm-up, external services).
+   */
+  initialDelay?: number;
 } & ( // make timeZone & utcOffset mutually exclusive
   | {
       timeZone?: string;

--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -17,7 +17,9 @@ type CronOptionsHost = {
 
 type IntervalOptions = TargetHost & TimeoutHost & RefHost<number>;
 type TimeoutOptions = TargetHost & TimeoutHost & RefHost<number>;
-type CronJobOptions = TargetHost & CronOptionsHost & RefHost<CronJob>;
+type CronJobOptions = TargetHost &
+  CronOptionsHost &
+  RefHost<CronJob> & { initialDelayRef?: ReturnType<typeof setTimeout> };
 
 @Injectable()
 export class SchedulerOrchestrator
@@ -70,11 +72,19 @@ export class SchedulerOrchestrator
       const cronJob = CronJob.from({
         ...options,
         onTick: target as CronCallback<null, false>,
-        start: !options.disabled,
+        start: !options.disabled && !options.initialDelay,
       });
 
       this.cronJobs[key].ref = cronJob;
       this.schedulerRegistry.addCronJob(key, cronJob);
+
+      if (options.initialDelay && options.initialDelay > 0 && !options.disabled) {
+        this.cronJobs[key].initialDelayRef = setTimeout(() => {
+          if (this.schedulerRegistry.doesExist('cron', key)) {
+            cronJob.start();
+          }
+        }, options.initialDelay);
+      }
     });
   }
 
@@ -91,6 +101,11 @@ export class SchedulerOrchestrator
   }
 
   closeCronJobs() {
+    Object.values(this.cronJobs).forEach(({ initialDelayRef }) => {
+      if (initialDelayRef !== undefined) {
+        clearTimeout(initialDelayRef);
+      }
+    });
     Array.from(this.schedulerRegistry.getCronJobs().keys()).forEach((key) =>
       this.schedulerRegistry.deleteCronJob(key),
     );

--- a/tests/e2e/cron-jobs.spec.ts
+++ b/tests/e2e/cron-jobs.spec.ts
@@ -293,6 +293,63 @@ describe('Cron', () => {
     expect(service.doesExist('dynamic')).toEqual(false);
   });
 
+  it('should not execute "cron" before initialDelay elapses', async () => {
+    const service = app.get(CronService);
+    await app.init();
+    const registry = app.get(SchedulerRegistry);
+    deleteAllRegisteredJobsExceptOne(registry, 'INITIAL_DELAY');
+
+    // Job should not have fired yet
+    clock.tick(4999);
+    expect(service.initialDelayCalls).toEqual(0);
+
+    // After initialDelay (5000ms) the cron starts; one tick at t=6000ms
+    clock.tick(1001);
+    expect(service.initialDelayCalls).toEqual(1);
+  });
+
+  it('should execute "cron" on schedule after initialDelay', async () => {
+    const service = app.get(CronService);
+    await app.init();
+    const registry = app.get(SchedulerRegistry);
+    deleteAllRegisteredJobsExceptOne(registry, 'INITIAL_DELAY');
+
+    // No ticks before the delay
+    clock.tick(5000);
+    // Cron fires every second; advance 3 more seconds
+    clock.tick(3000);
+    expect(service.initialDelayCalls).toEqual(3);
+  });
+
+  it('should not start "cron" when both disabled and initialDelay are set', async () => {
+    const service = app.get(CronService);
+    await app.init();
+    const registry = app.get(SchedulerRegistry);
+
+    expect(
+      registry.getCronJob('DISABLED_WITH_INITIAL_DELAY').isActive,
+    ).toBeFalsy();
+
+    clock.tick(5000);
+    expect(service.initialDelayCalls).toEqual(0);
+    expect(
+      registry.getCronJob('DISABLED_WITH_INITIAL_DELAY').isActive,
+    ).toBeFalsy();
+  });
+
+  it('should not start "cron" after shutdown when initialDelay is pending', async () => {
+    const service = app.get(CronService);
+    await app.init();
+
+    // Close the app before the 5s delay elapses
+    clock.tick(2000);
+    await app.close();
+
+    // Advance past the original delay — timeout must have been cleared
+    clock.tick(5000);
+    expect(service.initialDelayCalls).toEqual(0);
+  });
+
   it(`should not log a warning when the provider is not request scoped`, async () => {
     const logger = {
       log: jest.fn(),

--- a/tests/src/cron.service.ts
+++ b/tests/src/cron.service.ts
@@ -69,6 +69,16 @@ export class CronService {
   })
   handleDisabledCron() {}
 
+  @Cron(CronExpression.EVERY_SECOND, {
+    name: 'DISABLED_WITH_INITIAL_DELAY',
+    disabled: true,
+    initialDelay: 1000,
+    utcOffset: 0,
+  })
+  handleDisabledCronWithInitialDelay() {
+    ++this.initialDelayCalls;
+  }
+
   addCronJob(): CronJob {
     const job = new CronJob(CronExpression.EVERY_SECOND, () => {
       ++this.dynamicCallsCount;
@@ -95,6 +105,17 @@ export class CronService {
       const ref = this.schedulerRegistry.getCronJob('WAIT_FOR_COMPLETION');
       ref!.stop();
     }
+  }
+
+  initialDelayCalls = 0;
+
+  @Cron(CronExpression.EVERY_SECOND, {
+    name: 'INITIAL_DELAY',
+    initialDelay: 5000,
+    utcOffset: 0,
+  })
+  handleCronWithInitialDelay() {
+    ++this.initialDelayCalls;
   }
 
   doesExist(name: string): boolean {


### PR DESCRIPTION
## Summary

Adds an optional `initialDelay` (in ms) to `CronOptions`. When set, the first execution is deferred by the given number of milliseconds after application bootstrap; all subsequent runs follow the normal cron schedule.

```ts
@Cron(CronExpression.EVERY_MINUTE, {
  name: 'MY_JOB',
  initialDelay: 5000, // wait 5s before first run
})
handleCron() { ... }
```

## Motivation

Closes #2169.

Applications commonly run bootstrap logic on startup (database migrations, cache warm-up, waiting for external services). Cron jobs that depend on these resources can fail or produce inconsistent results if they fire before initialisation is complete. `initialDelay` allows the job to sit out that window without requiring any manual workaround.

## Implementation

- `CronOptions.initialDelay?: number` — new option with JSDoc
- `mountCron()` — when `initialDelay` is set the job is created with `start: false`; a `setTimeout` fires after the delay and starts the job only if it is still registered (`doesExist` guard handles the case where the job is deleted before the delay elapses)
- `closeCronJobs()` — clears all pending `initialDelayRef` timeouts before tearing down jobs, so a shutdown before the delay elapses leaves no dangling timers

## Test plan

Four new e2e tests added to `tests/e2e/cron-jobs.spec.ts`:

- [ ] Job does **not** fire before `initialDelay` elapses
- [ ] Job fires on schedule **after** `initialDelay`
- [ ] `disabled: true` + `initialDelay` — job never starts
- [ ] App shutdown before delay elapses — no fire after shutdown

All 49 integration tests pass (`npm run test:integration`).