### PR TITLE
feat: allow resolving @Cron options via dependency injection with factory providers

### DIFF
--- a/lib/decorators/cron.decorator.ts
+++ b/lib/decorators/cron.decorator.ts
@@ -8,6 +8,30 @@ import {
 } from '../schedule.constants';
 
 /**
+ * Describes how to resolve a cron option value lazily, from the DI container,
+ * once the application has been bootstrapped (e.g. to read it from a
+ * `ConfigService`). The factory is invoked with the providers listed in
+ * `inject`, resolved through `ModuleRef`.
+ *
+ * @example
+ * { inject: [ConfigService], useFactory: (config) => config.get('CRON_TIME') }
+ *
+ * @publicApi
+ */
+export type CronOptionFactory<T> = {
+  inject?: any[];
+  useFactory: (...args: any[]) => T | Promise<T>;
+};
+
+/**
+ * A cron option that is either a plain value or a {@link CronOptionFactory}
+ * resolved from the DI container at bootstrap time.
+ *
+ * @publicApi
+ */
+export type Resolvable<T> = T | CronOptionFactory<T>;
+
+/**
  * Reference links: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cron/index.d.ts
  *
  * @publicApi
@@ -30,19 +54,19 @@ export type CronOptions = {
   /**
    * If you have code that keeps the event loop running and want to stop the node process when that finishes regardless of the state of your cronjob, you can do so making use of this parameter. This is off by default and cron will run as if it needs to control the event loop. For more information take a look at [timers#timers_timeout_unref](https://nodejs.org/api/timers.html#timers_timeout_unref) from the NodeJS docs.
    */
-  unrefTimeout?: boolean;
+  unrefTimeout?: Resolvable<boolean>;
 
   /**
    * If true, no additional instances of cronjob will run until the current onTick callback has completed.
    * Any new scheduled executions that occur while the current cronjob is running will be skipped entirely.
    */
-  waitForCompletion?: boolean;
+  waitForCompletion?: Resolvable<boolean>;
 
   /**
    * This flag indicates whether the job will be executed at all.
    * @default false
    */
-  disabled?: boolean;
+  disabled?: Resolvable<boolean>;
 
   /**
    *  Threshold in ms to control whether to execute or skip missed execution deadlines caused by slow or busy hardware.
@@ -50,7 +74,7 @@ export type CronOptions = {
    *  In both cases a warning will be printed to the console with the job name and cron expression.
    *  Default is 250
    */
-  threshold?: number;
+  threshold?: Resolvable<number>;
 
   /**
    * Delay in milliseconds before the first cron execution after application bootstrap.
@@ -58,8 +82,32 @@ export type CronOptions = {
    * Useful when the job depends on resources that are not yet ready at application startup
    * (e.g. database connections, cache warm-up, external services).
    */
-  initialDelay?: number;
+  initialDelay?: Resolvable<number>;
 } & ( // make timeZone & utcOffset mutually exclusive
+  | {
+      timeZone?: Resolvable<string>;
+      utcOffset?: never;
+    }
+  | {
+      timeZone?: never;
+      utcOffset?: Resolvable<number>;
+    }
+);
+
+/**
+ * {@link CronOptions} after every {@link Resolvable} field has been resolved to
+ * a plain value. This is what the scheduler works with internally.
+ *
+ * @publicApi
+ */
+export type ResolvedCronOptions = {
+  name?: string;
+  unrefTimeout?: boolean;
+  waitForCompletion?: boolean;
+  disabled?: boolean;
+  threshold?: number;
+  initialDelay?: number;
+} & (
   | {
       timeZone?: string;
       utcOffset?: never;
@@ -72,13 +120,13 @@ export type CronOptions = {
 
 /**
  * Creates a scheduled job.
- * @param cronTime The time to fire off your job. This can be in the form of cron syntax, a JS ```Date``` object or a Luxon ```DateTime``` object.
+ * @param cronTime The time to fire off your job. This can be in the form of cron syntax, a JS ```Date``` object or a Luxon ```DateTime``` object. It may also be a {@link CronOptionFactory} to resolve the value from the DI container at bootstrap time.
  * @param options Job execution options.
  *
  * @publicApi
  */
 export function Cron(
-  cronTime: CronJobParams['cronTime'],
+  cronTime: Resolvable<CronJobParams['cronTime']>,
   options: CronOptions = {},
 ): MethodDecorator {
   const name = options?.name;

--- a/lib/schedule.explorer.ts
+++ b/lib/schedule.explorer.ts
@@ -1,11 +1,22 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { DiscoveryService, MetadataScanner } from '@nestjs/core';
+import { DiscoveryService, MetadataScanner, ModuleRef } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import { CronJobParams } from 'cron';
+import {
+  CronOptionFactory,
+  CronOptions,
+  Resolvable,
+  ResolvedCronOptions,
+} from './decorators/cron.decorator';
 import { SchedulerType } from './enums/scheduler-type.enum';
 import { SchedulerMetadataAccessor } from './schedule-metadata.accessor';
 import { SchedulerOrchestrator } from './scheduler.orchestrator';
 import { ScheduleModuleOptions } from './interfaces/schedule-module-options.interface';
 import { SCHEDULE_MODULE_OPTIONS } from './schedule.constants';
+
+type CronMetadata = CronOptions & Record<'cronTime', CronJobParams['cronTime']>;
+type ResolvedCronMetadata = ResolvedCronOptions &
+  Record<'cronTime', CronJobParams['cronTime']>;
 
 @Injectable()
 export class ScheduleExplorer implements OnModuleInit {
@@ -18,17 +29,19 @@ export class ScheduleExplorer implements OnModuleInit {
     private readonly discoveryService: DiscoveryService,
     private readonly metadataAccessor: SchedulerMetadataAccessor,
     private readonly metadataScanner: MetadataScanner,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
-  onModuleInit() {
-    this.explore();
+  async onModuleInit() {
+    await this.explore();
   }
 
-  explore() {
+  async explore() {
     const instanceWrappers: InstanceWrapper[] = [
       ...this.discoveryService.getControllers(),
       ...this.discoveryService.getProviders(),
     ];
+    const pending: Promise<unknown>[] = [];
     instanceWrappers.forEach((wrapper: InstanceWrapper) => {
       const { instance } = wrapper;
 
@@ -36,10 +49,14 @@ export class ScheduleExplorer implements OnModuleInit {
         return;
       }
 
-      const processMethod = (name: string) =>
-        wrapper.isDependencyTreeStatic()
+      const processMethod = (name: string) => {
+        const result = wrapper.isDependencyTreeStatic()
           ? this.lookupSchedulers(instance, name)
           : this.warnForNonStaticProviders(wrapper, instance, name);
+        if (result instanceof Promise) {
+          pending.push(result);
+        }
+      };
 
       // TODO(v4): remove this after dropping support for nestjs v9.3.2
       if (!Reflect.has(this.metadataScanner, 'getAllMethodNames')) {
@@ -56,9 +73,11 @@ export class ScheduleExplorer implements OnModuleInit {
         .getAllMethodNames(Object.getPrototypeOf(instance))
         .forEach(processMethod);
     });
+
+    await Promise.all(pending);
   }
 
-  lookupSchedulers(instance: Record<string, Function>, key: string) {
+  async lookupSchedulers(instance: Record<string, Function>, key: string) {
     const methodRef = instance[key];
     const metadata = this.metadataAccessor.getSchedulerType(methodRef);
 
@@ -69,8 +88,11 @@ export class ScheduleExplorer implements OnModuleInit {
         }
         const cronMetadata = this.metadataAccessor.getCronMetadata(methodRef);
         const cronFn = this.wrapFunctionInTryCatchBlocks(methodRef, instance);
+        const resolvedMetadata = await this.resolveCronMetadata(
+          cronMetadata!,
+        );
 
-        return this.schedulerOrchestrator.addCron(cronFn, cronMetadata!);
+        return this.schedulerOrchestrator.addCron(cronFn, resolvedMetadata);
       }
       case SchedulerType.TIMEOUT: {
         if (!this.moduleOptions.timeouts) {
@@ -148,6 +170,41 @@ export class ScheduleExplorer implements OnModuleInit {
         break;
       }
     }
+  }
+
+  private async resolveCronMetadata(
+    metadata: CronMetadata,
+  ): Promise<ResolvedCronMetadata> {
+    const entries = await Promise.all(
+      Object.entries(metadata).map(async ([key, value]) => {
+        // `name` is the registry key, not a resolvable value.
+        if (key === 'name') {
+          return [key, value] as const;
+        }
+        return [key, await this.resolveValue(value)] as const;
+      }),
+    );
+    return Object.fromEntries(entries) as ResolvedCronMetadata;
+  }
+
+  private async resolveValue<T>(value: Resolvable<T>): Promise<T> {
+    if (!this.isCronOptionFactory<T>(value)) {
+      return value;
+    }
+    const deps = (value.inject ?? []).map((token) =>
+      this.moduleRef.get(token, { strict: false }),
+    );
+    return value.useFactory(...deps);
+  }
+
+  private isCronOptionFactory<T>(
+    value: Resolvable<T>,
+  ): value is CronOptionFactory<T> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as CronOptionFactory<T>).useFactory === 'function'
+    );
   }
 
   private wrapFunctionInTryCatchBlocks(methodRef: Function, instance: object) {

--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -4,7 +4,7 @@ import {
   OnApplicationBootstrap,
 } from '@nestjs/common';
 import { CronCallback, CronJob, CronJobParams } from 'cron';
-import { CronOptions } from './decorators/cron.decorator';
+import { ResolvedCronOptions } from './decorators/cron.decorator';
 import { SchedulerRegistry } from './scheduler.registry';
 
 type TargetHost = { target: Function };
@@ -12,7 +12,7 @@ type TimeoutHost = { timeout: number };
 type RefHost<T> = { ref?: T };
 
 type CronOptionsHost = {
-  options: CronOptions & Record<'cronTime', CronJobParams['cronTime']>;
+  options: ResolvedCronOptions & Record<'cronTime', CronJobParams['cronTime']>;
 };
 
 type IntervalOptions = TargetHost & TimeoutHost & RefHost<number>;
@@ -78,7 +78,11 @@ export class SchedulerOrchestrator
       this.cronJobs[key].ref = cronJob;
       this.schedulerRegistry.addCronJob(key, cronJob);
 
-      if (options.initialDelay && options.initialDelay > 0 && !options.disabled) {
+      if (
+        options.initialDelay &&
+        options.initialDelay > 0 &&
+        !options.disabled
+      ) {
         this.cronJobs[key].initialDelayRef = setTimeout(() => {
           if (this.schedulerRegistry.doesExist('cron', key)) {
             cronJob.start();
@@ -111,14 +115,22 @@ export class SchedulerOrchestrator
     );
   }
 
-  addTimeout(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+  addTimeout(
+    methodRef: Function,
+    timeout: number,
+    name: string = crypto.randomUUID(),
+  ) {
     this.timeouts[name] = {
       target: methodRef,
       timeout,
     };
   }
 
-  addInterval(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+  addInterval(
+    methodRef: Function,
+    timeout: number,
+    name: string = crypto.randomUUID(),
+  ) {
     this.intervals[name] = {
       target: methodRef,
       timeout,
@@ -127,7 +139,8 @@ export class SchedulerOrchestrator
 
   addCron(
     methodRef: Function,
-    options: CronOptions & Record<'cronTime', CronJobParams['cronTime']>,
+    options: ResolvedCronOptions &
+      Record<'cronTime', CronJobParams['cronTime']>,
   ) {
     const name = options.name || crypto.randomUUID();
     this.cronJobs[name] = {

--- a/tests/e2e/resolvable-cron-options.spec.ts
+++ b/tests/e2e/resolvable-cron-options.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { CronExpression } from '../../lib';
+import { SchedulerRegistry } from '../../lib/scheduler.registry';
+import { AppModule } from '../src/app.module';
+
+describe('Cron - Resolvable options (DI)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.registerConfigResolvedCron()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should resolve "cronTime" from the DI container', async () => {
+    const registry = app.get(SchedulerRegistry);
+    const job = registry.getCronJob('CONFIG_RESOLVED_CRON_TIME');
+
+    expect(job.cronTime.source).toEqual(CronExpression.EVERY_SECOND);
+    expect(job.isActive).toBe(true);
+  });
+
+  it('should resolve "disabled" from the DI container', async () => {
+    const registry = app.get(SchedulerRegistry);
+
+    expect(registry.getCronJob('CONFIG_RESOLVED_DISABLED').isActive).toBe(
+      false,
+    );
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -6,6 +6,8 @@ import { RequestScopedCronService } from './request-scoped-cron.service';
 import { RequestScopedIntervalService } from './request-scoped-interval.service';
 import { RequestScopedTimeoutService } from './request-scoped-timeout.service';
 import { TimeoutService } from './timeout.service';
+import { ConfigService } from './config.service';
+import { ConfigResolvedCronService } from './config-resolved-cron.service';
 import { ScheduleModuleOptions } from '../../lib/interfaces/schedule-module-options.interface';
 
 @Module({})
@@ -67,6 +69,16 @@ export class AppModule {
       module: AppModule,
       imports: [ScheduleModule.forRoot(scheduleModuleOptions)],
       providers: [RequestScopedCronService],
+    };
+  }
+
+  static registerConfigResolvedCron(
+    scheduleModuleOptions?: ScheduleModuleOptions,
+  ): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [ScheduleModule.forRoot(scheduleModuleOptions)],
+      providers: [ConfigService, ConfigResolvedCronService],
     };
   }
 }

--- a/tests/src/config-resolved-cron.service.ts
+++ b/tests/src/config-resolved-cron.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '../../lib/decorators';
+import { CronExpression } from '../../lib/enums';
+import { ConfigService } from './config.service';
+
+@Injectable()
+export class ConfigResolvedCronService {
+  callsCount = 0;
+
+  @Cron(
+    {
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => config.get('CRON_EXPRESSION'),
+    },
+    {
+      name: 'CONFIG_RESOLVED_CRON_TIME',
+      utcOffset: 0,
+    },
+  )
+  handleCron() {
+    ++this.callsCount;
+  }
+
+  @Cron(CronExpression.EVERY_SECOND, {
+    name: 'CONFIG_RESOLVED_DISABLED',
+    disabled: {
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => config.get('CRON_DISABLED'),
+    },
+    utcOffset: 0,
+  })
+  handleDisabledCron() {}
+}

--- a/tests/src/config.service.ts
+++ b/tests/src/config.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { CronExpression } from '../../lib/enums';
+
+@Injectable()
+export class ConfigService {
+  private readonly store: Record<string, unknown> = {
+    CRON_EXPRESSION: CronExpression.EVERY_SECOND,
+    CRON_DISABLED: true,
+  };
+
+  get<T = unknown>(key: string): T {
+    return this.store[key] as T;
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

<!-- Public types carry JSDoc; the docs.nestjs.com techniques/task-scheduling page can be
     updated in a follow-up PR once the API shape is agreed on. -->

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`@Cron()`'s arguments — the cron expression and options such as `disabled` are evaluated at **class-definition time**, before Nest's DI container exists. There is therefore no way to drive them from `ConfigService` / environment variables:

```ts
// ❌ ConfigService does not exist yet when the decorator is evaluated
@Cron(configService.get('REPORT_CRON'), {
  disabled: configService.get('REPORT_DISABLED'),
})
handleReport() {}
```

In practice this forces teams to either hard-code schedules per environment, or abandon the declarative `@Cron` decorator and re-register jobs imperatively through `SchedulerRegistry` in an `onModuleInit` hook. Turning a job on/off or changing its schedule per environment (dev / staging / prod) without a code change is a common operational need today met only by workarounds.

Issue Number: N/A

## What is the new behavior?

Any `@Cron` value can now be declared as a `{ inject, useFactory }` factory in addition to a plain value. Factories are resolved through `ModuleRef` in `ScheduleExplorer` at `onModuleInit` — when the DI container is fully built — so values can come from `ConfigService` or any other provider:

```ts
@Cron(
  { inject: [ConfigService], useFactory: (c: ConfigService) => c.get('REPORT_CRON') },
  {
    name: 'report',
    disabled: { inject: [ConfigService], useFactory: (c: ConfigService) => c.get('REPORT_DISABLED') },
  },
)
handleReport() {}
```

Supported on `cronTime` and the option fields `disabled`, `timeZone`, `utcOffset`, `threshold`, `initialDelay`, `unrefTimeout`, `waitForCompletion`.

Implementation notes:

- New `CronOptionFactory<T>` / `Resolvable<T> = T | CronOptionFactory<T>` types. `CronOptionFactory` mirrors the shape of `@nestjs/common`'s `FactoryProvider` (`useFactory` + `inject`), so it's already familiar to Nest users.
- `ScheduleExplorer#onModuleInit` becomes async; it resolves each factory-shaped value via `ModuleRef` before handing fully-resolved options to the orchestrator. `onApplicationBootstrap` (where jobs are mounted) runs after all  `onModuleInit` hooks, so by mount time every value is already plain/synchronous.
- The orchestrator works against a `ResolvedCronOptions` type (plain values), so its bootstrap path is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`Resolvable<T>` is a superset of `T`, so all existing plain-value usages type-check and behave exactly as before. The factory path is only taken when a value is shaped like `{ useFactory: ... }`.

## Other information

This is mainly an inconvenience I keep running into myself and wanted to solve. If the direction here doesn't fit the philosophy of the project, please let me know — any feedback is welcome. Thanks for maintaining this package!
