### PR TITLE
fix(scheduler): reject duplicate scheduler names from decorators

### DIFF
--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { CronCallback, CronJob, CronJobParams } from 'cron';
 import { CronOptions } from './decorators/cron.decorator';
+import { DUPLICATE_SCHEDULER } from './schedule.messages';
 import { SchedulerRegistry } from './scheduler.registry';
 
 type TargetHost = { target: Function };
@@ -112,6 +113,9 @@ export class SchedulerOrchestrator
   }
 
   addTimeout(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+    if (Object.hasOwn(this.timeouts, name)) {
+      throw new Error(DUPLICATE_SCHEDULER('Timeout', name));
+    }
     this.timeouts[name] = {
       target: methodRef,
       timeout,
@@ -119,6 +123,9 @@ export class SchedulerOrchestrator
   }
 
   addInterval(methodRef: Function, timeout: number, name: string = crypto.randomUUID()) {
+    if (Object.hasOwn(this.intervals, name)) {
+      throw new Error(DUPLICATE_SCHEDULER('Interval', name));
+    }
     this.intervals[name] = {
       target: methodRef,
       timeout,
@@ -130,6 +137,9 @@ export class SchedulerOrchestrator
     options: CronOptions & Record<'cronTime', CronJobParams['cronTime']>,
   ) {
     const name = options.name || crypto.randomUUID();
+    if (Object.hasOwn(this.cronJobs, name)) {
+      throw new Error(DUPLICATE_SCHEDULER('Cron Job', name));
+    }
     this.cronJobs[name] = {
       target: methodRef,
       options,

--- a/tests/e2e/cron-jobs.spec.ts
+++ b/tests/e2e/cron-jobs.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { INestApplication, Logger } from '@nestjs/common';
+import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { CronJob } from 'cron';
-import { CronExpression } from '../../lib';
+import { Cron, CronExpression } from '../../lib';
+import { DUPLICATE_SCHEDULER } from '../../lib/schedule.messages';
+import { ScheduleModule } from '../../lib/schedule.module';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { CronService } from '../src/cron.service';
@@ -361,6 +363,29 @@ describe('Cron', () => {
     await app.init();
 
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it(`should throw when two providers declare a cron job with the same name`, async () => {
+    @Injectable()
+    class FirstService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'shared' })
+      handleCron() {}
+    }
+
+    @Injectable()
+    class SecondService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'shared' })
+      handleCron() {}
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [FirstService, SecondService],
+    }).compile();
+
+    await expect(module.createNestApplication().init()).rejects.toThrow(
+      DUPLICATE_SCHEDULER('Cron Job', 'shared'),
+    );
   });
 
   afterEach(async () => {

--- a/tests/e2e/interval.spec.ts
+++ b/tests/e2e/interval.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { INestApplication, Logger } from '@nestjs/common';
+import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { Interval } from '../../lib/decorators';
+import { DUPLICATE_SCHEDULER } from '../../lib/schedule.messages';
+import { ScheduleModule } from '../../lib/schedule.module';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { IntervalService } from '../src/interval.service';
@@ -126,6 +129,29 @@ describe('Interval', () => {
     await app.init();
 
     expect(logger.warn).not.toHaveBeenCalledWith();
+  });
+
+  it(`should throw when two providers declare an interval with the same name`, async () => {
+    @Injectable()
+    class FirstService {
+      @Interval('shared', 2500)
+      handleInterval() {}
+    }
+
+    @Injectable()
+    class SecondService {
+      @Interval('shared', 2500)
+      handleInterval() {}
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [FirstService, SecondService],
+    }).compile();
+
+    await expect(module.createNestApplication().init()).rejects.toThrow(
+      DUPLICATE_SCHEDULER('Interval', 'shared'),
+    );
   });
 
   afterEach(async () => {

--- a/tests/e2e/timeout.spec.ts
+++ b/tests/e2e/timeout.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { INestApplication, Logger } from '@nestjs/common';
+import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { Timeout } from '../../lib/decorators';
+import { DUPLICATE_SCHEDULER } from '../../lib/schedule.messages';
+import { ScheduleModule } from '../../lib/schedule.module';
 import { SchedulerRegistry } from '../../lib/scheduler.registry';
 import { AppModule } from '../src/app.module';
 import { nullPrototypeObjectProvider } from '../src/null-prototype-object.provider';
@@ -126,6 +129,29 @@ describe('Timeout', () => {
     await app.init();
 
     expect(logger.warn).not.toHaveBeenCalledWith();
+  });
+
+  it(`should throw when two providers declare a timeout with the same name`, async () => {
+    @Injectable()
+    class FirstService {
+      @Timeout('shared', 2500)
+      handleTimeout() {}
+    }
+
+    @Injectable()
+    class SecondService {
+      @Timeout('shared', 2500)
+      handleTimeout() {}
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [FirstService, SecondService],
+    }).compile();
+
+    await expect(module.createNestApplication().init()).rejects.toThrow(
+      DUPLICATE_SCHEDULER('Timeout', 'shared'),
+    );
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Declaring two schedulers with the same explicit name silently drops one of
them:

```ts
@Injectable()
class ReportService {
  @Interval('cleanup', 60_000)
  handleReports() {} // never runs
}

@Injectable()
class CacheService {
  @Interval('cleanup', 60_000)
  handleCache() {}
}
```

`SchedulerOrchestrator` stages decorator-declared schedulers in plain
objects keyed by name, and the second registration overwrites the first.
Only one entry survives to `mountIntervals()`, so `SchedulerRegistry` only
ever sees one name and its duplicate check never fires. No error, no
warning, and one of the two jobs simply never runs.

`SchedulerRegistry.addCronJob/addInterval/addTimeout` already throw
`DUPLICATE_SCHEDULER` when the dynamic API is called twice with one name,
so this applies the same rule to the decorator path. It throws while the
explorer collects the decorators, during `onModuleInit`, before anything is
scheduled.

This turns a silent misconfiguration into a startup error. An application
that has an accidental name collision today is already losing one of the two
schedulers, so it is broken either way, but it will now fail loudly on boot.
Happy to switch to a logged warning instead if you would rather not fail
initialization.

Affects `@Cron`, `@Interval` and `@Timeout` alike; tests added for all three.
