### PR TITLE
fix(cron): do not resurrect a deleted job after its initialDelay elapses

### DIFF
--- a/lib/scheduler.orchestrator.ts
+++ b/lib/scheduler.orchestrator.ts
@@ -81,7 +81,15 @@ export class SchedulerOrchestrator
 
       if (options.initialDelay && options.initialDelay > 0 && !options.disabled) {
         this.cronJobs[key].initialDelayRef = setTimeout(() => {
-          if (this.schedulerRegistry.doesExist('cron', key)) {
+          // Only start the job if it is still the one registered under this
+          // name: the job may have been deleted while the delay was pending,
+          // and a different job may even have been registered under the same
+          // name afterwards. Starting the captured reference would resurrect
+          // the deleted job and run both jobs in parallel.
+          if (
+            this.schedulerRegistry.doesExist('cron', key) &&
+            this.schedulerRegistry.getCronJob(key) === cronJob
+          ) {
             cronJob.start();
           }
         }, options.initialDelay);

--- a/tests/e2e/cron-initial-delay.spec.ts
+++ b/tests/e2e/cron-initial-delay.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { INestApplication, Injectable } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { CronJob } from 'cron';
+import { Cron, CronExpression } from '../../lib/index.js';
+import { ScheduleModule } from '../../lib/schedule.module.js';
+import { SchedulerRegistry } from '../../lib/scheduler.registry.js';
+
+@Injectable()
+class ResurrectionService {
+  oldJobCalls = 0;
+
+  @Cron(CronExpression.EVERY_SECOND, {
+    name: 'RESURRECT_ME',
+    initialDelay: 5000,
+  })
+  oldJob() {
+    ++this.oldJobCalls;
+  }
+}
+
+describe('Cron initialDelay resurrection', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [ResurrectionService],
+    }).compile();
+
+    app = module.createNestApplication();
+    vi.useFakeTimers({ now: 1577836800000 }); // 2020-01-01T00:00:00.000Z
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await app.close();
+  });
+
+  it('does not resurrect a deleted initialDelay job when its name is re-registered', async () => {
+    const service = app.get(ResurrectionService);
+    const registry = app.get(SchedulerRegistry);
+    await app.init();
+
+    // Delete the job while its initialDelay timer is still pending.
+    registry.deleteCronJob('RESURRECT_ME');
+
+    // Register a brand-new job under the same name.
+    let newCalls = 0;
+    const replacement = CronJob.from({
+      cronTime: CronExpression.EVERY_SECOND,
+      onTick: () => {
+        ++newCalls;
+      },
+    });
+    registry.addCronJob('RESURRECT_ME', replacement);
+    replacement.start();
+
+    // Advance well past the original 5s initialDelay deadline.
+    vi.advanceTimersByTime(7000);
+
+    // The new job keeps ticking...
+    expect(newCalls).toBeGreaterThan(0);
+    // ...while the deleted job must never execute again.
+    expect(service.oldJobCalls).toEqual(0);
+  });
+});


### PR DESCRIPTION
## Problem

A cron job declared with `initialDelay` keeps a plain `setTimeout` whose callback only checked `doesExist('cron', name)` before calling `cronJob.start()`. Two consequences:

1. If the job is **deleted** while the delay is pending, the captured reference is still started once the delay elapses — the deleted job runs forever.
2. If a **different job is registered under the same name** in that window, both the old and the new job run in parallel.

Reproduction (new e2e test in this PR, fails without the fix):

```
registry.deleteCronJob('RESURRECT_ME');          // during initialDelay window
registry.addCronJob('RESURRECT_ME', replacement); // same name, new job
vi.advanceTimersByTime(7000);                     // past the 5s delay
// old job ticked twice; expected zero times
```

## Fix

The timer now starts the job only when the registry still maps that name to exactly the same `CronJob` instance:

```ts
if (
  this.schedulerRegistry.doesExist('cron', key) &&
  this.schedulerRegistry.getCronJob(key) === cronJob
) {
  cronJob.start();
}
```

The `doesExist` guard stays so deleting a delayed job without re-registering does not throw from the timer callback.

## Testing

- new test: `tests/e2e/cron-initial-delay.spec.ts`
- full suite: 6 files / 53 tests passing