### PR TITLE
feat: export ScheduleExplorer from the package entry point

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,4 +2,5 @@ export * from './enums/index.js';
 export * from './decorators/index.js';
 export * from './interfaces/schedule-module-options.interface.js';
 export * from './schedule.module.js';
+export * from './schedule.explorer.js';
 export * from './scheduler.registry.js';


### PR DESCRIPTION
The explorer is the only supported hook for instrumenting scheduled handlers, but it was never re-exported from lib/index.ts. Before v12 an APM agent could still reach it with a deep import; the exports map added in v12 closes that path, leaving no supported way to get at it.

Export it so consumers get a stable, typed import.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
